### PR TITLE
Python3 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 1.0b2 (unreleased)
 ------------------
 
+- Make python3 compatible. [erral]
+
 - Update uninstall profile. [fredvd]
 
 

--- a/src/collective/behavior/seo/browser/metafields.py
+++ b/src/collective/behavior/seo/browser/metafields.py
@@ -10,11 +10,13 @@ class MetaFieldsViewlet(common.DublinCoreViewlet):
         super(MetaFieldsViewlet, self).update()
 
         if ISEOFieldsMarker.providedBy(self.context):
-
+            # in python3 this is a dict_items instance
+            self.metatags = list(self.metatags)
             if self.context.seo_description:
                 for index, (key, value) in enumerate(self.metatags):
                     if key == 'description':
                         self.metatags.pop(index)
                         break
+
                 self.metatags.append(
                     ('description', self.context.seo_description))


### PR DESCRIPTION
In python3 the return value of the `items()` method of dict returns a `dict_items` instance which is inmutable. Forcing it to be a list we can make this add-on compatible with python3 and Plone 5.2